### PR TITLE
Bugfix Uninitialised config no longer throws error on list

### DIFF
--- a/installer.php
+++ b/installer.php
@@ -20,7 +20,7 @@ namespace
     $n = PHP_EOL;
 
     set_error_handler(
-        function ($code, $message, $file, $line) use ($n) {
+        function ($code, $message) use ($n) {
             if ($code & error_reporting()) {
                 echo "$n{$n}Error: $message$n$n";
                 exit(1);
@@ -81,7 +81,7 @@ namespace
         'The "phar.readonly" setting is off.',
         'Notice: The "phar.readonly" setting needs to be off to create Phars.',
         function () {
-            return (false == ini_get('phar.readonly'));
+            return (ini_get_bool('phar.readonly') === false);
         },
         false
     );
@@ -91,7 +91,7 @@ namespace
         'The "detect_unicode" setting is off.',
         'The "detect_unicode" setting needs to be off.',
         function () {
-            return (false == ini_get('detect_unicode'));
+            return (ini_get_bool('detect_unicode') === false);
         }
     );
 
@@ -119,7 +119,7 @@ namespace
         'The "allow_url_fopen" setting is on.',
         'The "allow_url_fopen" setting needs to be on.',
         function () {
-            return (true == ini_get('allow_url_fopen'));
+            return ini_get_bool('allow_url_fopen');
         }
     );
 
@@ -172,7 +172,9 @@ namespace
 
     echo " - Making Host executable...$n";
 
-    @chmod($item->name, 0755);
+    if (@chmod($item->name, 0755) === false) {
+        throw new \RuntimeException('Permissions on '.$item->name.' could not be changed.');
+    }
 
     echo "{$n}Host installed!$n";
 
@@ -197,6 +199,15 @@ namespace
                 exit(1);
             }
         }
+    }
+
+    /**
+     * @param string $varname
+     *
+     * @return bool
+     */
+    function ini_get_bool($varname) {
+        return \filter_var(\ini_get($varname), FILTER_VALIDATE_BOOLEAN);
     }
 }
 

--- a/src/Services/Provider/Filesystem.php
+++ b/src/Services/Provider/Filesystem.php
@@ -238,7 +238,7 @@ class Filesystem
     public function addScope($config, $scope)
     {
         // do not add Scope during update. Scope will always be set when reading configuration.
-        if (!$this->_isUpdate && is_array($config)) {
+        if (!$this->_isUpdate && is_array($config) && isset($config['hosts'])) {
             foreach ($config['hosts'] as $key => $entry) {
                 $config['hosts'][$key]['scope'] = $scope;
             }

--- a/tests/Services/Provider/FilesystemTest.php
+++ b/tests/Services/Provider/FilesystemTest.php
@@ -450,12 +450,26 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
      * @test
      * @return void
      */
-    public function addScopeWillReturnEmptyConfigWithHostsValueOnEmptyConfigParameter()
+    public function addScopeWillReturnEmptyConfigWithHostsValueOnNonArrayConfigParameter()
     {
         $filesystem = new Filesystem($this->fileSystem, $this->file);
 
         $result = $filesystem->addScope(null,null);
 
         self::assertSame(['hosts' => []], $result);
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function addScopeWillNotModifyConfigParameterIfHostsKeyIsNotSet()
+    {
+        $config = [];
+        $filesystem = new Filesystem($this->fileSystem, $this->file);
+
+        $result = $filesystem->addScope([], 'foobar');
+
+        self::assertSame($config, $result);
     }
 }


### PR DESCRIPTION
If the config wasn't initialised, a call of the "hosts:list" command would throw an "undefined index" error.
Added an isset to prevent this